### PR TITLE
Dockerfile: Fixing COPY

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -4,12 +4,12 @@ FROM golang:1.19.4-alpine3.17 as build
 WORKDIR /go/src/app
 
 ## Dependencies
-COPY go.mod go.sum .
+COPY go.mod go.sum ./
 RUN go mod download
 
 ## Source code
 COPY cmd cmd
-COPY main.go .
+COPY main.go ./
 
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o /go/bin/audiotheker -ldflags="-s -w" main.go
 


### PR DESCRIPTION
Fixing the issue:

`When using COPY with more than one source file, the destination must be a directory and end with a /`